### PR TITLE
Configure maxRetries on AWS SDK services

### DIFF
--- a/main/lib/index.js
+++ b/main/lib/index.js
@@ -5,8 +5,8 @@ var Promise = require('bluebird');
 var _ = require('lodash');
 
 
-var ecr = Promise.promisifyAll(new AWS.ECR({region: process.env.REPO_REGION}));
-var ecs = Promise.promisifyAll(new AWS.ECS({region: process.env.ECS_REGION}));
+var ecr = Promise.promisifyAll(new AWS.ECR({region: process.env.REPO_REGION, maxRetries: 3}));
+var ecs = Promise.promisifyAll(new AWS.ECS({region: process.env.ECS_REGION, maxRetries: 3}));
 
 /**
  * Lib


### PR DESCRIPTION
Fixes #2. This should allow rate limited operations to be retried (they will be if `maxRetries > 0`).

The default maxRetries for a service is supposed to be 3 (https://github.com/aws/aws-sdk-js/blob/master/lib/service.js#L130), but this doesn't seem to be happening for the services we create here. i.e.:

``` js
var service = new AWS.ECR({region: process.env.REPO_REGION});
console.log(service.config.maxRetries);  # -> undefined
```
