### PR TITLE
Not giving REPO_TO_CLEAN is fatal, not a warning, and we don't default to us-east-1

### DIFF
--- a/main/handler.js
+++ b/main/handler.js
@@ -35,7 +35,7 @@ module.exports.handler = function(event, context) {
   }
 
   if(!process.env.REPO_TO_CLEAN){
-    console.error('WARN: NO REPO_TO_CLEAN, defaulting to us-east-1');
+    console.error('ERROR: NO REPO_TO_CLEAN, must be set');
     return context.fail(new Error('Must set REPO_TO_CLEAN'));
   }
 


### PR DESCRIPTION
Just a small fix for a confusing error message
