### PR TITLE
Support for multiple repos in a backwards-compatable way

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Install Dependencies
 
 Setup environment variables... (Be sure to remove the comments!)
 
+If you want to clean multiple repositories, separate them with commas as below:
+
 ```
 # _meta/variables/s-variables-common.json
 
@@ -31,7 +33,7 @@ Setup environment variables... (Be sure to remove the comments!)
   "domain": "ecr-cleaner",
   "notificationEmail": "johndoe@example.com",
   "region": "us-east-1",
-  "repoToClean": "ecr-cleanup-target",
+  "repoToClean": "ecr-cleanup-target,another-target",
   "repoRegion": "us-east-1", // DEFAULT
   "ecsRegion": "us-east-1", // DEFAULT
   "repoAgeThreshold": 90, // DEFAULT
@@ -91,6 +93,8 @@ console or when running locally.
 
 // Local run command: sls function run main --stage dev
 ```
+
+
 
 # Many Thanks
 

--- a/main/event.json
+++ b/main/event.json
@@ -1,3 +1,5 @@
 {
-	"dryRun":true
+	"dryRun":"true",
+	"repoAgeThreshold": 10,
+	"cleaningRepos": "aroth-test"
 }

--- a/main/handler.js
+++ b/main/handler.js
@@ -14,15 +14,6 @@ module.exports.handler = function(event, context) {
     process.env.DRY_RUN = false;
   }
 
-  if(event.repoAgeThreshold){
-    process.env.REPO_AGE_THRESHOLD = event.repoAgeThreshold;
-  }else{
-    process.env.REPO_AGE_THRESHOLD = 90;
-  }
-
-  if(event.cleaningRepos){
-    process.env.REPO_TO_CLEAN = event.cleaningRepos;
-  }
 
   if(!process.env.AWS_ACCOUNT_ID){
     console.warn('WARN: NO AWS_ACCOUNT_ID, defaulting to current account');


### PR DESCRIPTION
These changes allow for multiple repositories to be cleaned by comma-separating the list of repos in the config.

This shouldn't break existing configs, but makes it significantly easier to use for larger organizations.